### PR TITLE
IE10+ compatibility

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -23,7 +23,7 @@ var Sortable = {
     e.dataTransfer.effectAllowed = 'move';
     try {
       e.dataTransfer.setData('text/html', null);
-    } catch (e) {
+    } catch (ex) {
       e.dataTransfer.setData('text', '');
     }
   },


### PR DESCRIPTION
- fixed `dataset` missing in IE10
- fixed `dataTransfer.setData()` accepting only `'text'` and non-null value in IE10 and IE11

Example still does not work fully in IE10+, but at least it does not throw errors.

Also I've made a running example at http://jsbin.com/yicoluki/1/edit
Maybe it is worth mentioning in README
