### PR TITLE
fix draggable elements in IE11.

### DIFF
--- a/demo/gridlist/gridlist.css
+++ b/demo/gridlist/gridlist.css
@@ -13,6 +13,14 @@ ul {
   background:#ddd;
 }
 li {
+  /*
+   * IE doesn't seem to fire `dragover` event on block-level items.
+   * developers should take care to ensure that draggables are not
+   * `display: block`:
+   */
+  display: inline-block;
+  width: 100%;
+
   padding: 10px;
   color: #666;
   line-height: 17px;

--- a/demo/nested/nested.css
+++ b/demo/nested/nested.css
@@ -14,6 +14,14 @@ ul {
 }
 
 li {
+  /*
+   * IE doesn't seem to fire `dragover` event on block-level items.
+   * developers should take care to ensure that draggables are not
+   * `display: block`:
+   */
+  display: inline-block;
+  width: 100%;
+
   color: #666;
   margin-left: 10px;
   border-left: 1px solid gold;


### PR DESCRIPTION
I'm playing with React and the drag-and-drop API. I _love_ your demo.

I discovered that it isn't working in IE. Here's what I found:

IE doesn't seem to fire `dragover` event on block-level items. As developers, it seems incumbent on us to  ensure that draggables are not set to `display: block` if we want HTML5 drag-and-drop to work in IE.

If you open IE11, you'll notice that in your demo, the grid view works perfectly but the list view on the left side does not allow dragging at all. This changeset seems to solve the problem. IE exhausts me. 