### PR TITLE
another way to fix IE11 draggables:

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -4,6 +4,9 @@ var Sortable = {
       "data-id" : this.props.key,
       draggable : true,
       onDragEnd: this.sortEnd.bind(this),
+      onDragEnter: function(event) {
+        event.preventDefault();
+      },
       onDragOver: this.dragOver.bind(this),
       onDragStart: this.sortStart.bind(this)
     }


### PR DESCRIPTION
IE seems to need the default behavior for `dragenter` to be prevented in
order to get to the `dragover` event in some cases.

As mentioned in #9, there's another way to do this:
IE will respect the `dragover` event without any
issue if the element is something other than a basic `display: block`.

This pull request suggests another way to solve the problem.