### PR TITLE
Preserve drag image for list items with anchor tag

### DIFF
--- a/lib/SortableComposition.js
+++ b/lib/SortableComposition.js
@@ -86,6 +86,7 @@ function SortableComposition(Component) {
         draggingIndex: draggingIndex
       });
       if (e.dataTransfer !== undefined) {
+        e.dataTransfer.setDataImage(e.target, 0, 0);
         e.dataTransfer.setData('text', e.target);
       }
       updateEdge = true;

--- a/src/SortableComposition.js
+++ b/src/SortableComposition.js
@@ -68,13 +68,16 @@ export function SortableComposition(Component) {
 
     sortStart(e) {
       const draggingIndex = e.currentTarget.dataset.id;
+
       this.props.updateState({
         draggingIndex: draggingIndex
       });
       this.setState({
         draggingIndex: draggingIndex
       });
+
       if (e.dataTransfer !== undefined) {
+        e.dataTransfer.setDragImage(e.target, 0, 0);
         e.dataTransfer.setData('text', e.target);
       }
       updateEdge = true;
@@ -87,9 +90,9 @@ export function SortableComposition(Component) {
       var height, topOffset;
       var items = this.props.items;
       const overEl = e.currentTarget; //underlying element //TODO: not working for touch
-      const indexDragged = Number(overEl.dataset.id); //index of underlying element in the set DOM elements 
+      const indexDragged = Number(overEl.dataset.id); //index of underlying element in the set DOM elements
       const indexFrom = Number(this.state.draggingIndex);
-      
+
       height = overEl.getBoundingClientRect().height;
 
       if(e.type === "dragover"){
@@ -97,8 +100,8 @@ export function SortableComposition(Component) {
         positionY = e.clientY;
         topOffset = overEl.getBoundingClientRect().top;
       }
-    
-      if (e.type === "touchmove") { 
+
+      if (e.type === "touchmove") {
         positionX = e.touches[0].pageX;
         positionY = e.touches[0].pageY;
         if(updateEdge){
@@ -109,7 +112,7 @@ export function SortableComposition(Component) {
         //e.currentTarget.style.top = (positionY - elementEdge) + "px";
         topOffset = elementEdge;
       }
-      
+
       if (this.props.outline === "list") {
          //console.log('isMouseBeyond(positionY, topOffset, height)', positionY, topOffset, height, isMouseBeyond(positionY, topOffset, height))
           mouseBeyond = isMouseBeyond(positionY, topOffset, height)
@@ -155,4 +158,3 @@ export function SortableComposition(Component) {
 
   })
 }
-


### PR DESCRIPTION
Preserve drag image for list items with anchor tag.  When using anchor tags, the drag image gets converted to a browser native implementation. http://stackoverflow.com/questions/27656183/preserve-appearance-of-dragged-a-element-when-using-html5-draggable-attribute