### PR TITLE
Add babel-cli as dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-dom": "15.x.x"
   },
   "devDependencies": {
+    "babel-cli": "6.14.x",
     "babel-core": "6.14.x",
     "babel-jest": "14.x.x",
     "babel-preset-es2015": "6.14.x",


### PR DESCRIPTION
- Added `babel-cli` as dev dependency for new machines without babel-cli installed globally. Will now work on local project fork