### PR TITLE
fix: Sortable uppercase compatibility fix

### DIFF
--- a/__tests__/import-test.js
+++ b/__tests__/import-test.js
@@ -1,0 +1,27 @@
+jest.autoMockOff();
+
+describe('import test', () => {
+
+  it('should import sortable', () => {
+
+    // when
+    var sortable = require('../src').sortable;
+
+    // then
+    expect(sortable).not.toBeUndefined();
+  });
+
+
+  // Sortable with uppercase S for compatibility reasons
+  // danielstocks/react-sortable/issues/57
+  // TODO: remove with release 2.0.0
+  it('should import Sortable (uppercase S)', () => {
+
+    // when
+    var SortableUppercase = require('../src').Sortable;
+
+    // then
+    expect(SortableUppercase).not.toBeUndefined();
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Make your React components sortable.",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,6 @@
 export { SortableComposition as sortable } from './SortableComposition';
+
+// export Sortable with uppercase S for compatibility reasons
+// danielstocks/react-sortable/issues/57
+// TODO: remove with release 2.0.0
+export { SortableComposition as Sortable } from './SortableComposition';


### PR DESCRIPTION
src/index.js now exports lower- and uppercase sortable. This fix should be removed with release 2.0.0
- added tests
- bumped version to 1.2.1

referenced to #49
closes #57

see http://semver.org/
