### PR TITLE
Fixed sortEnd on drop

### DIFF
--- a/lib/SortableComposition.js
+++ b/lib/SortableComposition.js
@@ -6,43 +6,15 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-exports.swapArrayElements = swapArrayElements;
-exports.isMouseBeyond = isMouseBeyond;
 exports.SortableComposition = SortableComposition;
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _helpers = require('./helpers.js');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-/*** Helper functions - they are decoupled from component itself for testability */
-
-/**
- * @param {array} items
- * @param {number} indexFrom
- * @param {number} indexTo
- * @returns {array}
- */
-function swapArrayElements(items, indexFrom, indexTo) {
-  var item = items[indexTo];
-  items[indexTo] = items[indexFrom];
-  items[indexFrom] = item;
-  return items;
-}
-
-/**
- * @param {number} mousePos
- * @param {number} elementPos
- * @param {number} elementSize
- * @returns {boolean}
- */
-function isMouseBeyond(mousePos, elementPos, elementSize) {
-  //TODO refactor for UP
-  var breakPoint = elementSize / 2; //break point is set to the middle line of element
-  var mouseOverlap = mousePos - elementPos;
-  return mouseOverlap > breakPoint;
-}
 
 /*** Higher-order component - this component works like a factory for draggable items */
 
@@ -105,7 +77,7 @@ function SortableComposition(Component) {
       var positionX, positionY;
       var height, topOffset;
       var items = this.props.items;
-      var overEl = e.currentTarget; //underlying element //TODO: not working for touch
+      var overEl = e.currentTarget; //underlying element
       var indexDragged = Number(overEl.dataset.id); //index of underlying element in the set DOM elements
       var indexFrom = Number(this.state.draggingIndex);
 
@@ -116,15 +88,15 @@ function SortableComposition(Component) {
       topOffset = overEl.getBoundingClientRect().top;
 
       if (this.props.outline === "list") {
-        mouseBeyond = isMouseBeyond(positionY, topOffset, height);
+        mouseBeyond = (0, _helpers.isMouseBeyond)(positionY, topOffset, height);
       }
 
       if (this.props.outline === "grid") {
-        mouseBeyond = isMouseBeyond(positionX, overEl.getBoundingClientRect().left, overEl.getBoundingClientRect().width);
+        mouseBeyond = (0, _helpers.isMouseBeyond)(positionX, overEl.getBoundingClientRect().left, overEl.getBoundingClientRect().width);
       }
 
       if (indexDragged !== indexFrom && mouseBeyond) {
-        items = swapArrayElements(items, indexFrom, indexDragged);
+        items = (0, _helpers.swapArrayElements)(items, indexFrom, indexDragged);
         this.props.updateState({
           items: items, draggingIndex: indexDragged
         });
@@ -141,9 +113,7 @@ function SortableComposition(Component) {
         onDragOver: this.dragOver,
         onDragStart: this.sortStart,
         onDragEnd: this.sortEnd,
-        onDrop: function onDrop(e) {
-          e.preventDefault();
-        },
+        onDrop: this.sortEnd,
         onTouchStart: this.sortStart,
         onTouchMove: this.dragOver,
         onTouchEnd: this.sortEnd,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.swapArrayElements = swapArrayElements;
 exports.isMouseBeyond = isMouseBeyond;
-/*** Helper functions - they are decoupled from component itself for testability */
+/*** Helper functions - they are decoupled because of testability */
 
 /**
  * @param {array} items

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,11 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _SortableDragEvent = require('./SortableDragEvent');
+var _SortableComposition = require('./SortableComposition');
 
 Object.defineProperty(exports, 'sortable', {
   enumerable: true,
   get: function get() {
-    return _SortableDragEvent.Sortable;
+    return _SortableComposition.SortableComposition;
   }
 });

--- a/src/SortableComposition.js
+++ b/src/SortableComposition.js
@@ -106,7 +106,7 @@ export function SortableComposition(Component) {
           onDragOver={this.dragOver}
           onDragStart={this.sortStart}
           onDragEnd={this.sortEnd}
-          onDrop={function(e){e.preventDefault();}}
+          onDrop={this.sortEnd}
           onTouchStart={this.sortStart}
           onTouchMove={this.dragOver}
           onTouchEnd={this.sortEnd}


### PR DESCRIPTION
The isDragging is not refreshed and this caused a `-dragging` class is not being removed on latest version.