### PR TITLE
Use PropTypes form package 'prop-types' instead of 'react'

### DIFF
--- a/lib/SortableComposition.js
+++ b/lib/SortableComposition.js
@@ -14,6 +14,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _helpers = require('./helpers.js');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -31,7 +35,6 @@ function SortableComposition(Component) {
   var elementEdge = 0;
   var updateEdge = true;
 
-  //return React.createClass({
   return function (_React$Component) {
     _inherits(Sortable, _React$Component);
 
@@ -46,51 +49,18 @@ function SortableComposition(Component) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Sortable.__proto__ || Object.getPrototypeOf(Sortable)).call.apply(_ref, [this].concat(args))), _this), _this.state = { draggingIndex: null }, _temp), _possibleConstructorReturn(_this, _ret);
-    }
-
-    /*getInitialState() {
-      return {
-        draggingIndex: null
-      }
-    },
-     getDefaultProps() {
-      return {
-       }
-    },*/
-    /*constructor(props) {
-      super(props);
-      this.state = {
-         draggingIndex: null
-      };
-    }*/
-
-
-    _createClass(Sortable, [{
-      key: 'componentWillReceiveProps',
-      value: function componentWillReceiveProps(nextProps) {
-        this.setState({
-          draggingIndex: nextProps.draggingIndex
-        });
-      }
-    }, {
-      key: 'sortEnd',
-      value: function sortEnd(e) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Sortable.__proto__ || Object.getPrototypeOf(Sortable)).call.apply(_ref, [this].concat(args))), _this), _this.state = { draggingIndex: null }, _this.sortEnd = function (e) {
         e.preventDefault();
-        this.props.updateState({
+        _this.props.updateState({
           draggingIndex: null
         });
-      }
-    }, {
-      key: 'sortStart',
-      value: function sortStart(e) {
+      }, _this.sortStart = function (e) {
         var draggingIndex = e.currentTarget.dataset.id;
-
-        this.props.updateState({
+        _this.props.updateState({
           draggingIndex: draggingIndex
         });
 
-        this.setState({
+        _this.setState({
           draggingIndex: draggingIndex
         });
 
@@ -104,24 +74,21 @@ function SortableComposition(Component) {
           }
         }
         updateEdge = true;
-      }
-    }, {
-      key: 'dragOver',
-      value: function dragOver(e) {
+      }, _this.dragOver = function (e) {
         e.preventDefault();
         var mouseBeyond;
         var positionX, positionY;
         var height, topOffset;
-        var items = this.props.items;
-        var _props = this.props,
-            outline = _props.outline,
-            moveInMiddle = _props.moveInMiddle,
-            sortId = _props.sortId,
-            draggingIndex = _props.draggingIndex;
+        var items = _this.props.items;
+        var _this$props = _this.props,
+            outline = _this$props.outline,
+            moveInMiddle = _this$props.moveInMiddle,
+            sortId = _this$props.sortId,
+            draggingIndex = _this$props.draggingIndex;
 
         var overEl = e.currentTarget; //underlying element
         var indexDragged = Number(overEl.dataset.id); //index of underlying element in the set DOM elements
-        var indexFrom = Number(this.state.draggingIndex);
+        var indexFrom = Number(_this.state.draggingIndex);
 
         height = overEl.getBoundingClientRect().height;
 
@@ -139,17 +106,26 @@ function SortableComposition(Component) {
 
         if (indexDragged !== indexFrom && mouseBeyond) {
           items = (0, _helpers.swapArrayElements)(items, indexFrom, indexDragged);
-          this.props.updateState({
+          _this.props.updateState({
             items: items, draggingIndex: indexDragged
           });
         }
+      }, _temp), _possibleConstructorReturn(_this, _ret);
+    }
+
+    _createClass(Sortable, [{
+      key: 'componentWillReceiveProps',
+      value: function componentWillReceiveProps(nextProps) {
+        this.setState({
+          draggingIndex: nextProps.draggingIndex
+        });
       }
     }, {
       key: 'isDragging',
       value: function isDragging() {
-        var _props2 = this.props,
-            draggingIndex = _props2.draggingIndex,
-            sortId = _props2.sortId;
+        var _props = this.props,
+            draggingIndex = _props.draggingIndex,
+            sortId = _props.sortId;
 
         return draggingIndex == sortId;
       }
@@ -177,12 +153,12 @@ function SortableComposition(Component) {
   }(_react2.default.Component);
 
   Sortable.propTypes = {
-    items: _react2.default.PropTypes.array.isRequired,
-    updateState: _react2.default.PropTypes.func.isRequired,
-    sortId: _react2.default.PropTypes.number,
-    outline: _react2.default.PropTypes.string.isRequired, // list | grid
-    draggingIndex: _react2.default.PropTypes.number,
-    childProps: _react2.default.PropTypes.object
+    items: _propTypes2.default.array.isRequired,
+    updateState: _propTypes2.default.func.isRequired,
+    sortId: _propTypes2.default.number,
+    outline: _propTypes2.default.string.isRequired, // list | grid
+    draggingIndex: _propTypes2.default.number,
+    childProps: _propTypes2.default.object
 
   };
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Daniel Stocks <daniel@webcloud.se>",
   "license": "MIT",
   "peerDependencies": {
+    "prop-types": "^15.5.10",
     "react": "15.x.x",
     "react-dom": "15.x.x"
   },

--- a/src/SortableComposition.js
+++ b/src/SortableComposition.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { swapArrayElements, isMouseBeyond } from './helpers.js';
 
 /*** Higher-order component - this component works like a factory for draggable items */
@@ -8,7 +9,6 @@ export function SortableComposition(Component) {
   var elementEdge = 0;
   var updateEdge = true;
 
-  //return React.createClass({
 return class Sortable extends React.Component {
 
     state = { draggingIndex: null };
@@ -110,12 +110,12 @@ return class Sortable extends React.Component {
   }
 
   Sortable.propTypes = {
-      items: React.PropTypes.array.isRequired,
-      updateState: React.PropTypes.func.isRequired,
-      sortId: React.PropTypes.number,
-      outline: React.PropTypes.string.isRequired, // list | grid
-      draggingIndex: React.PropTypes.number,
-      childProps: React.PropTypes.object,
+      items: PropTypes.array.isRequired,
+      updateState: PropTypes.func.isRequired,
+      sortId: PropTypes.number,
+      outline: PropTypes.string.isRequired, // list | grid
+      draggingIndex: PropTypes.number,
+      childProps: PropTypes.object,
 
   };
 


### PR DESCRIPTION
Since react 15.5 we've been getting a warning about importing PropTypes from prop-types instead of react, this is said to be a breaking change in React 16.