### PR TITLE
Restored isDragging prop

### DIFF
--- a/src/SortableComposition.js
+++ b/src/SortableComposition.js
@@ -82,7 +82,7 @@ return class Sortable extends React.Component {
 
     }
 
-    isDragging() {
+    isDragging = () => {
       const { draggingIndex, sortId } = this.props
       return draggingIndex == sortId;
     }
@@ -92,6 +92,7 @@ return class Sortable extends React.Component {
       return (
         <Component
           className={this.isDragging() ? draggingClassName : ""}
+          isDragging={this.isDragging}
           draggable={true}
           onDragOver={this.dragOver}
           onDragStart={this.sortStart}


### PR DESCRIPTION
The previous version of the library contained prop isDragging. Now it's missing and the hoc passes className instead, but Component.displayName is corrupted by minification usually. Anyway, it will be useful to have the oppurtunity to set own class without format limitations by the library, and more importantly to have the opportunity to use the function isDragging in any custom logic.